### PR TITLE
#36 Preimenovati dependency platform u graph_platform

### DIFF
--- a/graph_explorer/setup.py
+++ b/graph_explorer/setup.py
@@ -7,7 +7,7 @@ setup(
     description="Django aplikacija za vizualizaciju i upravljanje grafovima koristeći platform i pluginove",
     packages=find_packages(),
     install_requires=[
-        "platform>=0.1.0",
+        "graph_platform>=0.1.0",
         "data_source_csv>=0.1.0",
         "data_source_json>=0.1.0",
         "simple_visualizer>=0.1.0",


### PR DESCRIPTION
Ovaj PR ispravlja grešku u `graph_explorer` paketu gde je u zavisnostima bio naveden nepostojeći pip paket `platform`. Pošto je `platform` ugrađeni Python modul, instalacija projekta je padala.

Zavisnost je zamenjena ispravnim lokalnim paketom `graph_platform`, čime instalacija ponovo funkcioniše.

### Šta je urađeno
- Uklonjen `platform>=0.1.0` iz `setup` konfiguracije
- Dodat dependency `graph_platform`
- Proverena ispravnost instalacije

