### PR TITLE
#53 Popravka prikaza grafova i CSS layouta u Graph Explorer-u

### DIFF
--- a/block_visualizer/block_visualizer/plugin.py
+++ b/block_visualizer/block_visualizer/plugin.py
@@ -42,7 +42,7 @@ class BlockVisualizer(BaseVisualizer):
                     if (!mainContainer || !birdContainer) return;
 
                     const width = mainContainer.clientWidth;
-                    const height = 600;
+                    const height = mainContainer.clientHeight;
                     
                     // Skaliranje za minimapu
                     const minimapScale = 0.2; 
@@ -220,7 +220,7 @@ class BlockVisualizer(BaseVisualizer):
         js_code = js_logic.replace("GRAPH_DATA_PLACEHOLDER", graph_json)
 
         return f"""
-        <div id="block-viz-container" style="width:100%; height:600px; border:1px solid #ddd; background: #f9f9f9;"></div>
+        <div id="block-viz-container" style="width:100%; height:100%; border:1px solid #ddd; background: #f9f9f9;"></div>
         <script>
             {js_code}
         </script>

--- a/graph_explorer/graph_explorer_package/core/templates/core/index.html
+++ b/graph_explorer/graph_explorer_package/core/templates/core/index.html
@@ -242,7 +242,7 @@
         </div>
 
         <main class="main-view" id="main-container">
-            <div id="main-content" style="width: 100%; height: 100%; overflow: auto;">
+            <div id="main-content" style="width: 100%; height: 100%;">
                 <div style="text-align: center; padding-top: 50px; color: #888;">
                     <h2>Main View Canvas</h2>
                     <p>Select a file and click Load Graph</p>
@@ -347,6 +347,8 @@
                 headers: { "X-CSRFToken": getCSRFToken() }
              });
             refreshVisualization();
+        }
+
         function changeVisualizer() {
             if (currentGraphId) {
                 loadVisualization(currentGraphId);

--- a/simple_visualizer/simple_visualizer/plugin.py
+++ b/simple_visualizer/simple_visualizer/plugin.py
@@ -31,7 +31,7 @@ class SimpleVisualizer(BaseVisualizer):
                     if (!mainContainer || !birdContainer) return;
 
                     const width = mainContainer.clientWidth;
-                    const height = 600; 
+                    const height = mainContainer.clientHeight; 
                     
                     // Skaliranje za minimapu (20% velicine)
                     const minimapScale = 0.2; 
@@ -182,7 +182,7 @@ class SimpleVisualizer(BaseVisualizer):
         js_code = js_code.replace("GRAPH_DATA_PLACEHOLDER", graph_json)
 
         return f"""
-        <div id="simple-viz-container" style="width:100%; height:600px; border:1px solid #ddd; background: white;"></div>
+        <div id="simple-viz-container" style="width:100%; height:100%; border:1px solid #ddd; background: white;"></div>
         <script>
             {js_code}
         </script>


### PR DESCRIPTION
## Opis izmene
Tokom mergeovanja nestala je viticastu zagrada u `index.html`, što je vraćeno da template funkcioniše ispravno.

Dodatno su izvršene sledeće izmene radi poboljšanja prikaza grafova:

- Uklonjen `overflow: auto` sa `#main-content` diva koji je pravio nepotrebne scrollove.
- U oba vizualizera (`simple` i `block`) canvas (`svg`) je postavljen da zauzima punu visinu umesto fiksnih 600px.

Closes #53